### PR TITLE
fix: add missing demonstrateReservedNames() call in main

### DIFF
--- a/examples/agent-naming/main.go
+++ b/examples/agent-naming/main.go
@@ -29,6 +29,7 @@ func main() {
 
 	// demonstrate agent config integration
 	demonstrateAgentConfigIntegration()
+	demonstrateReservedNames()
 }
 
 func demonstrateBasicValidation() {


### PR DESCRIPTION
Added the missing demonstrateReservedNames() call to main(). The function was defined but never invoked, making it dead code.